### PR TITLE
update test suite to using SOAP messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     },
     "require-dev": {
         "beste/clock": "~3.0.0",
+        "mockery/mockery": "~1.6.12",
         "simplesamlphp/simplesamlphp-test-framework": "~1.9.3"
     },
     "support": {

--- a/src/Controller/AttributeServer.php
+++ b/src/Controller/AttributeServer.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\exampleattributeserver\Controller;
 
 use DateInterval;
-use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
-use SimpleSAML\Message;
 use SimpleSAML\{Configuration, Error, Logger};
 use SimpleSAML\HTTP\RunnableResponse;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
-use SimpleSAML\SAML2\Binding;
 use SimpleSAML\SAML2\Binding\{SynchronousBindingInterface, SOAP};
 use SimpleSAML\SAML2\Constants as C;
 use SimpleSAML\SAML2\Utils as SAML2_Utils;
@@ -36,7 +33,6 @@ use SimpleSAML\XMLSecurity\Key\PrivateKey;
 use SimpleSAML\XMLSecurity\XML\ds\{KeyInfo, X509Certificate, X509Data};
 use SimpleSAML\XMLSecurity\XML\SignableElementInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\{HttpFoundationFactory, PsrHttpFactory};
-use Symfony\Component\HttpFoundation\Request;
 
 use function array_filter;
 

--- a/src/Controller/AttributeServer.php
+++ b/src/Controller/AttributeServer.php
@@ -6,6 +6,8 @@ namespace SimpleSAML\Module\exampleattributeserver\Controller;
 
 use DateInterval;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+use SimpleSAML\Message;
 use SimpleSAML\{Configuration, Error, Logger};
 use SimpleSAML\HTTP\RunnableResponse;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
@@ -82,22 +84,9 @@ class AttributeServer
      * @return \SimpleSAML\HTTP\RunnableResponse
      * @throws \SimpleSAML\Error\BadRequest
      */
-    public function main(/** @scrutinizer ignore-unused */ Request $request): RunnableResponse
+    public function main(/** @scrutinizer ignore-unused */ SOAP $soap, ServerRequest $request): RunnableResponse
     {
-        $psr17Factory = new Psr17Factory();
-        $psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
-        $psrRequest = $psrHttpFactory->createRequest($request);
-
-        $binding = Binding::getCurrentBinding($psrRequest);
-        if (!($binding instanceof SynchronousBindingInterface)) {
-            throw new Error\BadRequest('Invalid binding; MUST use a synchronous binding.');
-        }
-
-        $message = $binding->receive($psrRequest);
-        if (!($message instanceof AttributeQuery)) {
-            throw new Error\BadRequest('Invalid message received to AttributeQuery endpoint.');
-        }
-
+        $message = $soap->receive($request);
         $idpEntityId = $this->metadataHandler->getMetaDataCurrentEntityID('saml20-idp-hosted');
 
         $issuer = $message->getIssuer();

--- a/src/Controller/AttributeServer.php
+++ b/src/Controller/AttributeServer.php
@@ -75,7 +75,7 @@ class AttributeServer
 
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request The current request.
+     * @param \Nyholm\Psr7\ServerRequest $request The current request.
      *
      * @return \SimpleSAML\HTTP\RunnableResponse
      * @throws \SimpleSAML\Error\BadRequest

--- a/tests/src/Controller/AttributeServerTest.php
+++ b/tests/src/Controller/AttributeServerTest.php
@@ -8,10 +8,10 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SimpleSAML\Configuration;
-use SimpleSAML\SAML2\Binding\SOAP;
 use SimpleSAML\HTTP\RunnableResponse;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\exampleattributeserver\Controller\AttributeServer;
+use SimpleSAML\SAML2\Binding\SOAP;
 use SimpleSAML\XMLSecurity\TestUtils\PEMCertificatesMock;
 
 /**

--- a/tests/src/Controller/AttributeServerTest.php
+++ b/tests/src/Controller/AttributeServerTest.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace SimpleSAML\Test\Module\exampleattributeserver\Controller;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\TestCase;
-use SimpleSAML\SAML2\Binding\SOAP;
 use SimpleSAML\Configuration;
+use SimpleSAML\SAML2\Binding\SOAP;
 use SimpleSAML\HTTP\RunnableResponse;
 use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Module\exampleattributeserver\Controller\AttributeServer;
 use SimpleSAML\XMLSecurity\TestUtils\PEMCertificatesMock;
-use Symfony\Component\HttpFoundation\Request;
-use SAML2\Message;
 
 /**
  * Set of tests for the controllers in the "exampleattributeserver" module.


### PR DESCRIPTION
I am not sure this is a complete update. The AttributeQuery came from the base64 decoded, deflated example contained in the original QUERY_STRING.

It might be an idea at some stage to include an `AuthnRequest` message. Though that sort of thing might be better focused into the main SSP test suite. Adding some more SOAP round trips there and verifying the `samlp:Response`.

Closes #17 